### PR TITLE
Fix Llama3 golden-value failures after checkpoint loading

### DIFF
--- a/models/codonfm/tests/common/test_modeling_common.py
+++ b/models/codonfm/tests/common/test_modeling_common.py
@@ -233,6 +233,21 @@ class BaseModelTest(ABC):
         """
         return ["bshd"]
 
+    def compare_thd_losses(
+        self,
+        bshd_loss: torch.Tensor,
+        thd_loss: torch.Tensor,
+        input_data_bshd: Dict[str, torch.Tensor],
+    ) -> None:
+        """Compare losses from equivalent BSHD and THD inputs."""
+        tolerances = self.get_tolerances()
+        torch.testing.assert_close(
+            bshd_loss,
+            thd_loss,
+            atol=tolerances.golden_value_loss_atol,
+            rtol=tolerances.golden_value_loss_rtol,
+        )
+
     def verify_model_parameters_initialized_correctly(
         self,
         model: PreTrainedModel,
@@ -756,22 +771,22 @@ class BaseModelTest(ABC):
         model_thd.eval()
         with torch.inference_mode():
             outputs_thd = model_thd(**input_data_thd)
+        thd_loss = outputs_thd.loss.detach().clone()
+        thd_logits = outputs_thd.logits.detach().clone()
+        del model_thd, outputs_thd
+        gc.collect()
+        torch.cuda.empty_cache()
 
         # Compare logits
         torch.testing.assert_close(
             bshd_logits,
-            outputs_thd.logits,
+            thd_logits,
             atol=tolerances.golden_value_logits_atol,
             rtol=tolerances.golden_value_logits_rtol,
         )
 
         # Compare losses
-        torch.testing.assert_close(
-            bshd_loss,
-            outputs_thd.loss,
-            atol=tolerances.golden_value_loss_atol,
-            rtol=tolerances.golden_value_loss_rtol,
-        )
+        self.compare_thd_losses(bshd_loss, thd_loss, input_data_bshd)
 
     def test_thd_padding_input_data_equivalence(self):
         """Test that the THD input data is the same before and after padding."""

--- a/models/esm2/tests/common/test_modeling_common.py
+++ b/models/esm2/tests/common/test_modeling_common.py
@@ -227,6 +227,21 @@ class BaseModelTest(ABC):
         """
         return ["bshd"]
 
+    def compare_thd_losses(
+        self,
+        bshd_loss: torch.Tensor,
+        thd_loss: torch.Tensor,
+        input_data_bshd: Dict[str, torch.Tensor],
+    ) -> None:
+        """Compare losses from equivalent BSHD and THD inputs."""
+        tolerances = self.get_tolerances()
+        torch.testing.assert_close(
+            bshd_loss,
+            thd_loss,
+            atol=tolerances.golden_value_loss_atol,
+            rtol=tolerances.golden_value_loss_rtol,
+        )
+
     def verify_model_parameters_initialized_correctly(
         self,
         model: PreTrainedModel,
@@ -750,22 +765,22 @@ class BaseModelTest(ABC):
         model_thd.eval()
         with torch.inference_mode():
             outputs_thd = model_thd(**input_data_thd)
+        thd_loss = outputs_thd.loss.detach().clone()
+        thd_logits = outputs_thd.logits.detach().clone()
+        del model_thd, outputs_thd
+        gc.collect()
+        torch.cuda.empty_cache()
 
         # Compare logits
         torch.testing.assert_close(
             bshd_logits,
-            outputs_thd.logits,
+            thd_logits,
             atol=tolerances.golden_value_logits_atol,
             rtol=tolerances.golden_value_logits_rtol,
         )
 
         # Compare losses
-        torch.testing.assert_close(
-            bshd_loss,
-            outputs_thd.loss,
-            atol=tolerances.golden_value_loss_atol,
-            rtol=tolerances.golden_value_loss_rtol,
-        )
+        self.compare_thd_losses(bshd_loss, thd_loss, input_data_bshd)
 
     def test_thd_padding_input_data_equivalence(self):
         """Test that the THD input data is the same before and after padding."""

--- a/models/llama3/modeling_llama_te.py
+++ b/models/llama3/modeling_llama_te.py
@@ -104,6 +104,7 @@ class NVLlamaPreTrainedModel(PreTrainedModel):
         self.model.embed_tokens.apply(self._init_weights)
 
         self.model.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=self.model.config).inv_freq.to("cuda")
+        self.model._rotary_inv_freq_needs_init = False
 
         # Meta-device init seems to break weight tying, so we re-tie the weights here.
         self.tie_weights()
@@ -122,6 +123,23 @@ class NVLlamaPreTrainedModel(PreTrainedModel):
             return
 
         super()._init_weights(module)
+
+    def tie_weights(self, *args, **kwargs):
+        """Tie model weights and restore the non-persistent rotary frequency buffer."""
+        super().tie_weights(*args, **kwargs)
+
+        llama_model = getattr(self, "model", self)
+        if not getattr(llama_model, "_rotary_inv_freq_needs_init", False):
+            return
+
+        device = llama_model.embed_tokens.weight.device
+        if device.type != "meta":
+            # Transformers 5 loads checkpoints through a meta-device model. Transformer Engine's
+            # non-persistent inv_freq buffer is therefore materialized without values, so rebuild it
+            # when from_pretrained() performs its final tie_weights() call after loading parameters.
+            with torch.device(device):
+                llama_model.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=llama_model.config).inv_freq
+            llama_model._rotary_inv_freq_needs_init = False
 
     def state_dict(self, *args, **kwargs):
         """Override state_dict to filter out TransformerEngine's _extra_state keys.
@@ -217,6 +235,7 @@ class NVLlamaModel(NVLlamaPreTrainedModel):
         # LlamaRotaryEmbedding.
         self.rotary_emb = RotaryPositionEmbedding(config.hidden_size // config.num_attention_heads)
         self.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=config).inv_freq
+        self._rotary_inv_freq_needs_init = self.rotary_emb.inv_freq.device.type == "meta"
 
         self._fp8_recipe: transformer_engine.common.recipe.Recipe | None = None
         self._fp4_recipe: transformer_engine.common.recipe.Recipe | None = None

--- a/models/llama3/tests/common/test_modeling_common.py
+++ b/models/llama3/tests/common/test_modeling_common.py
@@ -233,6 +233,21 @@ class BaseModelTest(ABC):
         """
         return ["bshd"]
 
+    def compare_thd_losses(
+        self,
+        bshd_loss: torch.Tensor,
+        thd_loss: torch.Tensor,
+        input_data_bshd: Dict[str, torch.Tensor],
+    ) -> None:
+        """Compare losses from equivalent BSHD and THD inputs."""
+        tolerances = self.get_tolerances()
+        torch.testing.assert_close(
+            bshd_loss,
+            thd_loss,
+            atol=tolerances.golden_value_loss_atol,
+            rtol=tolerances.golden_value_loss_rtol,
+        )
+
     def verify_model_parameters_initialized_correctly(
         self,
         model: PreTrainedModel,
@@ -756,22 +771,22 @@ class BaseModelTest(ABC):
         model_thd.eval()
         with torch.inference_mode():
             outputs_thd = model_thd(**input_data_thd)
+        thd_loss = outputs_thd.loss.detach().clone()
+        thd_logits = outputs_thd.logits.detach().clone()
+        del model_thd, outputs_thd
+        gc.collect()
+        torch.cuda.empty_cache()
 
         # Compare logits
         torch.testing.assert_close(
             bshd_logits,
-            outputs_thd.logits,
+            thd_logits,
             atol=tolerances.golden_value_logits_atol,
             rtol=tolerances.golden_value_logits_rtol,
         )
 
         # Compare losses
-        torch.testing.assert_close(
-            bshd_loss,
-            outputs_thd.loss,
-            atol=tolerances.golden_value_loss_atol,
-            rtol=tolerances.golden_value_loss_rtol,
-        )
+        self.compare_thd_losses(bshd_loss, thd_loss, input_data_bshd)
 
     def test_thd_padding_input_data_equivalence(self):
         """Test that the THD input data is the same before and after padding."""

--- a/models/llama3/tests/test_modeling_llama_te.py
+++ b/models/llama3/tests/test_modeling_llama_te.py
@@ -20,6 +20,7 @@ This file provides comprehensive tests for the LLaMA3 model including:
 - LLaMA-specific tests (inference, generation, THD inputs, etc.)
 """
 
+import gc
 from typing import Callable, Dict, List, Literal, Type
 
 import pytest
@@ -136,6 +137,61 @@ class TestLlama3Model(BaseModelTest):
             cp_loss_atol=0.5,
             cp_loss_rtol=0.25,
         )
+
+    def test_rotary_inv_freq_after_from_pretrained(self, tmp_path):
+        """The non-persistent TE rotary buffer is reinitialized after meta-device checkpoint loading."""
+        config = self.create_test_config(
+            dtype=torch.bfloat16,
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=128,
+        )
+        model = self.get_model_class()(config)
+        model.save_pretrained(tmp_path)
+
+        reloaded = self.get_model_class().from_pretrained(tmp_path, dtype=torch.bfloat16)
+        expected = transformers.models.llama.modeling_llama.LlamaRotaryEmbedding(config=reloaded.config).inv_freq
+
+        rotary_emb = reloaded.model.rotary_emb
+        assert "inv_freq" in rotary_emb._buffers
+        assert "inv_freq" in rotary_emb._non_persistent_buffers_set
+        assert rotary_emb.inv_freq.device == reloaded.model.embed_tokens.weight.device
+        assert rotary_emb.inv_freq.dtype == torch.float32
+        torch.testing.assert_close(rotary_emb.inv_freq.cpu(), expected)
+
+        # A later manual weight-tying call must not overwrite an intentionally customized RoPE buffer.
+        rotary_emb.inv_freq = torch.zeros_like(rotary_emb.inv_freq)
+        reloaded.tie_weights()
+        torch.testing.assert_close(rotary_emb.inv_freq, torch.zeros_like(rotary_emb.inv_freq))
+
+    def compare_thd_losses(
+        self,
+        bshd_loss: torch.Tensor,
+        thd_loss: torch.Tensor,
+        input_data_bshd: Dict[str, torch.Tensor],
+    ) -> None:
+        """Compare both TE input formats to the same Hugging Face reference loss."""
+        model_hf = self.get_reference_model(dtype=torch.bfloat16)
+        model_hf.eval()
+        with torch.inference_mode():
+            hf_loss = model_hf(**input_data_bshd).loss.detach().clone()
+        del model_hf
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        tolerances = self.get_tolerances()
+        for input_format, loss in (("bshd", bshd_loss), ("thd", thd_loss)):
+            torch.testing.assert_close(
+                loss,
+                hf_loss,
+                atol=tolerances.golden_value_loss_atol,
+                rtol=tolerances.golden_value_loss_rtol,
+                msg=lambda error, input_format=input_format: (
+                    f"{input_format.upper()} loss mismatch against Hugging Face: {error}"
+                ),
+            )
 
     # ==================== LLaMA3-Specific Overrides ====================
 

--- a/models/mixtral/tests/common/test_modeling_common.py
+++ b/models/mixtral/tests/common/test_modeling_common.py
@@ -233,6 +233,21 @@ class BaseModelTest(ABC):
         """
         return ["bshd"]
 
+    def compare_thd_losses(
+        self,
+        bshd_loss: torch.Tensor,
+        thd_loss: torch.Tensor,
+        input_data_bshd: Dict[str, torch.Tensor],
+    ) -> None:
+        """Compare losses from equivalent BSHD and THD inputs."""
+        tolerances = self.get_tolerances()
+        torch.testing.assert_close(
+            bshd_loss,
+            thd_loss,
+            atol=tolerances.golden_value_loss_atol,
+            rtol=tolerances.golden_value_loss_rtol,
+        )
+
     def verify_model_parameters_initialized_correctly(
         self,
         model: PreTrainedModel,
@@ -756,22 +771,22 @@ class BaseModelTest(ABC):
         model_thd.eval()
         with torch.inference_mode():
             outputs_thd = model_thd(**input_data_thd)
+        thd_loss = outputs_thd.loss.detach().clone()
+        thd_logits = outputs_thd.logits.detach().clone()
+        del model_thd, outputs_thd
+        gc.collect()
+        torch.cuda.empty_cache()
 
         # Compare logits
         torch.testing.assert_close(
             bshd_logits,
-            outputs_thd.logits,
+            thd_logits,
             atol=tolerances.golden_value_logits_atol,
             rtol=tolerances.golden_value_logits_rtol,
         )
 
         # Compare losses
-        torch.testing.assert_close(
-            bshd_loss,
-            outputs_thd.loss,
-            atol=tolerances.golden_value_loss_atol,
-            rtol=tolerances.golden_value_loss_rtol,
-        )
+        self.compare_thd_losses(bshd_loss, thd_loss, input_data_bshd)
 
     def test_thd_padding_input_data_equivalence(self):
         """Test that the THD input data is the same before and after padding."""

--- a/models/qwen/tests/common/test_modeling_common.py
+++ b/models/qwen/tests/common/test_modeling_common.py
@@ -233,6 +233,21 @@ class BaseModelTest(ABC):
         """
         return ["bshd"]
 
+    def compare_thd_losses(
+        self,
+        bshd_loss: torch.Tensor,
+        thd_loss: torch.Tensor,
+        input_data_bshd: Dict[str, torch.Tensor],
+    ) -> None:
+        """Compare losses from equivalent BSHD and THD inputs."""
+        tolerances = self.get_tolerances()
+        torch.testing.assert_close(
+            bshd_loss,
+            thd_loss,
+            atol=tolerances.golden_value_loss_atol,
+            rtol=tolerances.golden_value_loss_rtol,
+        )
+
     def verify_model_parameters_initialized_correctly(
         self,
         model: PreTrainedModel,
@@ -756,22 +771,22 @@ class BaseModelTest(ABC):
         model_thd.eval()
         with torch.inference_mode():
             outputs_thd = model_thd(**input_data_thd)
+        thd_loss = outputs_thd.loss.detach().clone()
+        thd_logits = outputs_thd.logits.detach().clone()
+        del model_thd, outputs_thd
+        gc.collect()
+        torch.cuda.empty_cache()
 
         # Compare logits
         torch.testing.assert_close(
             bshd_logits,
-            outputs_thd.logits,
+            thd_logits,
             atol=tolerances.golden_value_logits_atol,
             rtol=tolerances.golden_value_logits_rtol,
         )
 
         # Compare losses
-        torch.testing.assert_close(
-            bshd_loss,
-            outputs_thd.loss,
-            atol=tolerances.golden_value_loss_atol,
-            rtol=tolerances.golden_value_loss_rtol,
-        )
+        self.compare_thd_losses(bshd_loss, thd_loss, input_data_bshd)
 
     def test_thd_padding_input_data_equivalence(self):
         """Test that the THD input data is the same before and after padding."""

--- a/recipes/evo2_megatron/tests/bionemo/evo2/test_utils.py
+++ b/recipes/evo2_megatron/tests/bionemo/evo2/test_utils.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import sentinel
+
+from pytest import MonkeyPatch
+
+from . import utils
+
+
+def test_initialize_distributed_process_group_keeps_kernel_assigned_port_reserved(monkeypatch):
+    class FakeStore:
+        port = 41000
+
+    store = FakeStore()
+    tcp_store_calls = []
+    init_process_group_calls = []
+
+    def fake_tcp_store(**kwargs):
+        tcp_store_calls.append(kwargs)
+        return store
+
+    def fake_init_process_group(**kwargs):
+        init_process_group_calls.append(kwargs)
+
+    monkeypatch.setattr(utils.torch.distributed, "TCPStore", fake_tcp_store)
+    monkeypatch.setattr(utils.torch.distributed, "init_process_group", fake_init_process_group)
+    monkeypatch.setenv("MASTER_PORT", "original")
+
+    with MonkeyPatch.context() as environment:
+        utils._initialize_distributed_process_group(environment, sentinel.backend, rank=0, world_size=1)
+
+        assert os.environ["MASTER_PORT"] == "41000"
+
+    assert os.environ["MASTER_PORT"] == "original"
+    assert tcp_store_calls == [
+        {
+            "host_name": utils.DEFAULT_MASTER_ADDR,
+            "port": 0,
+            "world_size": 1,
+            "is_master": True,
+        }
+    ]
+    assert init_process_group_calls == [
+        {
+            "backend": sentinel.backend,
+            "store": store,
+            "rank": 0,
+            "world_size": 1,
+        }
+    ]

--- a/recipes/evo2_megatron/tests/bionemo/evo2/utils.py
+++ b/recipes/evo2_megatron/tests/bionemo/evo2/utils.py
@@ -16,7 +16,6 @@
 """Shared test utilities for evo2 tests."""
 
 import gc
-import socket
 from contextlib import contextmanager
 
 import megatron.core.num_microbatches_calculator
@@ -27,16 +26,34 @@ from pytest import MonkeyPatch
 
 
 DEFAULT_MASTER_ADDR = "localhost"
-DEFAULT_MASTER_PORT = "29500"
 DEFAULT_NCCL_TIMEOUT = "30"  # in seconds
 
 
-def find_free_network_port(address: str = "localhost") -> int:
-    """Find a free port on localhost for distributed testing."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((address, 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
+def _initialize_distributed_process_group(
+    context: MonkeyPatch,
+    backend: str,
+    rank: int,
+    world_size: int,
+) -> None:
+    """Initialize a process group using a TCPStore bound to a kernel-assigned port.
+
+    Passing port zero lets TCPStore bind an available port atomically. Keeping that
+    store alive and passing it to ``init_process_group`` avoids the race caused by
+    probing a port, releasing it, and then asking TCPStore to bind it again.
+    """
+    store = torch.distributed.TCPStore(
+        host_name=DEFAULT_MASTER_ADDR,
+        port=0,
+        world_size=world_size,
+        is_master=rank == 0,
+    )
+    context.setenv("MASTER_PORT", str(store.port))
+    torch.distributed.init_process_group(
+        backend=backend,
+        store=store,
+        rank=rank,
+        world_size=world_size,
+    )
 
 
 def get_compute_capability() -> tuple[int, int]:
@@ -183,14 +200,10 @@ def distributed_model_parallel_state(
             # distributed and parallel state set up
             if not torch.distributed.is_initialized():
                 context.setenv("MASTER_ADDR", DEFAULT_MASTER_ADDR)
-                free_network_port = find_free_network_port()
-                context.setenv(
-                    "MASTER_PORT", str(free_network_port) if free_network_port is not None else DEFAULT_MASTER_PORT
-                )
                 context.setenv("NCCL_TIMEOUT", DEFAULT_NCCL_TIMEOUT)
                 context.setenv("RANK", str(rank))
 
-                torch.distributed.init_process_group(backend=backend, world_size=world_size)
+                _initialize_distributed_process_group(context, backend, rank, world_size)
             parallel_state.initialize_model_parallel(**initialize_model_parallel_kwargs)
 
             # tensor parallel random seed set up

--- a/recipes/llama3_native_te/modeling_llama_te.py
+++ b/recipes/llama3_native_te/modeling_llama_te.py
@@ -110,6 +110,7 @@ class NVLlamaPreTrainedModel(PreTrainedModel):
         self.model.embed_tokens.apply(self._init_weights)
 
         self.model.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=self.model.config).inv_freq.to("cuda")
+        self.model._rotary_inv_freq_needs_init = False
 
         # Meta-device init seems to break weight tying, so we re-tie the weights here.
         self.tie_weights()
@@ -128,6 +129,23 @@ class NVLlamaPreTrainedModel(PreTrainedModel):
             return
 
         super()._init_weights(module)
+
+    def tie_weights(self, *args, **kwargs):
+        """Tie model weights and restore the non-persistent rotary frequency buffer."""
+        super().tie_weights(*args, **kwargs)
+
+        llama_model = getattr(self, "model", self)
+        if not getattr(llama_model, "_rotary_inv_freq_needs_init", False):
+            return
+
+        device = llama_model.embed_tokens.weight.device
+        if device.type != "meta":
+            # Transformers 5 loads checkpoints through a meta-device model. Transformer Engine's
+            # non-persistent inv_freq buffer is therefore materialized without values, so rebuild it
+            # when from_pretrained() performs its final tie_weights() call after loading parameters.
+            with torch.device(device):
+                llama_model.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=llama_model.config).inv_freq
+            llama_model._rotary_inv_freq_needs_init = False
 
     def state_dict(self, *args, **kwargs):
         """Override state_dict to filter out TransformerEngine's _extra_state keys.
@@ -223,6 +241,7 @@ class NVLlamaModel(NVLlamaPreTrainedModel):
         # LlamaRotaryEmbedding.
         self.rotary_emb = RotaryPositionEmbedding(config.hidden_size // config.num_attention_heads)
         self.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=config).inv_freq
+        self._rotary_inv_freq_needs_init = self.rotary_emb.inv_freq.device.type == "meta"
 
         self._fp8_recipe: transformer_engine.common.recipe.Recipe | None = None
         self._fp4_recipe: transformer_engine.common.recipe.Recipe | None = None

--- a/recipes/opengenome2_llama_native_te/modeling_llama_te.py
+++ b/recipes/opengenome2_llama_native_te/modeling_llama_te.py
@@ -110,6 +110,7 @@ class NVLlamaPreTrainedModel(PreTrainedModel):
         self.model.embed_tokens.apply(self._init_weights)
 
         self.model.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=self.model.config).inv_freq.to("cuda")
+        self.model._rotary_inv_freq_needs_init = False
 
         # Meta-device init seems to break weight tying, so we re-tie the weights here.
         self.tie_weights()
@@ -128,6 +129,23 @@ class NVLlamaPreTrainedModel(PreTrainedModel):
             return
 
         super()._init_weights(module)
+
+    def tie_weights(self, *args, **kwargs):
+        """Tie model weights and restore the non-persistent rotary frequency buffer."""
+        super().tie_weights(*args, **kwargs)
+
+        llama_model = getattr(self, "model", self)
+        if not getattr(llama_model, "_rotary_inv_freq_needs_init", False):
+            return
+
+        device = llama_model.embed_tokens.weight.device
+        if device.type != "meta":
+            # Transformers 5 loads checkpoints through a meta-device model. Transformer Engine's
+            # non-persistent inv_freq buffer is therefore materialized without values, so rebuild it
+            # when from_pretrained() performs its final tie_weights() call after loading parameters.
+            with torch.device(device):
+                llama_model.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=llama_model.config).inv_freq
+            llama_model._rotary_inv_freq_needs_init = False
 
     def state_dict(self, *args, **kwargs):
         """Override state_dict to filter out TransformerEngine's _extra_state keys.
@@ -223,6 +241,7 @@ class NVLlamaModel(NVLlamaPreTrainedModel):
         # LlamaRotaryEmbedding.
         self.rotary_emb = RotaryPositionEmbedding(config.hidden_size // config.num_attention_heads)
         self.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=config).inv_freq
+        self._rotary_inv_freq_needs_init = self.rotary_emb.inv_freq.device.type == "meta"
 
         self._fp8_recipe: transformer_engine.common.recipe.Recipe | None = None
         self._fp4_recipe: transformer_engine.common.recipe.Recipe | None = None


### PR DESCRIPTION
## What changed

- Cherry-pick `9a496964b533` from #1714 without modification.
- Reinitialize Transformer Engine's non-persistent rotary `inv_freq` buffer after meta-device checkpoint loading.
- Add regression coverage for `from_pretrained()` and improve shared golden-value test cleanup/comparison behavior.
- Preserve the related shared-harness and Evo2 test compatibility updates from the original commit so Git can recognize the same changes when #1714 merges.

## Why

Scheduled CI run https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/31477466541 failed three `models/llama3` golden-value tests. The TE model was loaded with an uninitialized RoPE buffer, producing losses of 8.0031 and 4.1343 versus the Hugging Face reference value of 2.0217. The `verify-recipe-tests` failure was a downstream aggregate failure.

Reusing the existing #1714 commit fixes the regression while minimizing future merge conflicts.

## Validation

- `python ci/scripts/check_copied_files.py --fix`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Python bytecode compilation for the changed Python modules
- `git diff --check upstream/main...HEAD`

The focused Llama3 GPU regression test could not run in the local host environment because PyTorch is not installed; the repository's CI model container provides the required PyTorch, Transformer Engine, and GPU runtime.
