### PR TITLE
fix(fp8-analysis): align NumPy with SciPy

### DIFF
--- a/recipes/fp8_analysis/requirements.txt
+++ b/recipes/fp8_analysis/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.10.1
-numpy==1.26.4
+numpy==2.1.0
 pandas==2.2.3
 seaborn==0.13.2
 pytest


### PR DESCRIPTION
## Summary

- update the FP8 analysis recipe to use NumPy 2.1.0
- keep the recipe dependency set compatible with SciPy 1.18.0 in the PyTorch 26.07 CI image

## Root cause

The recipe pinned NumPy 1.26.4, which downgraded the PyTorch 26.07 image's NumPy installation while leaving its preinstalled SciPy 1.18.0 in place. SciPy 1.18.0 requires NumPy >=2.0, so importing seaborn failed during pytest collection with `AttributeError: module 'numpy' has no attribute 'long'`.

## Impact

The `recipes/fp8_analysis` nightly unit-test lane can collect and execute normally with the current CI image.

## Validation

- installed SciPy 1.18.0 followed by `recipes/fp8_analysis/requirements.txt` in a fresh virtual environment
- `pip check`
- `pytest -v recipes/fp8_analysis` — 15 passed
- `python ci/scripts/check_copied_files.py`
- `pre-commit run --files recipes/fp8_analysis/requirements.txt`
- `git diff --check`

Fixes the failure in https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/31583004699.
