### PR TITLE
fix(ci): pin transformers<5 to fix tokenizer windowing regression

### DIFF
--- a/models/llama3/requirements.txt
+++ b/models/llama3/requirements.txt
@@ -2,5 +2,5 @@ lm-eval  # For testing
 torch
 torchao!=0.14.0
 transformer_engine[pytorch]
-transformers
+transformers<5
 pytest

--- a/recipes/llama3_native_te/requirements.txt
+++ b/recipes/llama3_native_te/requirements.txt
@@ -5,7 +5,7 @@ torchao!=0.14.0
 torchdata
 torchmetrics
 tqdm
-transformers
+transformers<5
 wandb
 zstandard
 nvdlfw_inspect @ git+https://github.com/NVIDIA/nvidia-dlfw-inspect


### PR DESCRIPTION
## Summary
Pins `transformers<5` in two recipe environments to fix tokenizer windowing regression introduced by transformers 5.16.1.

## Root Cause
Unpinned `transformers` resolved to 5.16.1 in the scheduled CI run (run 33072381885). Transformers 5 changes overflow-window behavior for the fast nucleotide tokenizer, yielding only 2 windows instead of the mathematically expected count (12, 47, 20, 7 depending on test).

## Failed Workflow
- Workflow: unit-tests-recipes.yml (ID 182833798)
- Run: https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/33072381885
- Failing SHA: e3efd35e177ab0b6fdea96a853f9f9271e71588c

## Failed Tests
1. `recipes/llama3_native_te/tests/test_dataset.py::test_windowing_in_dataset_creates_multiple_samples` - Expected 12 windows, got 2
2. `models/llama3/tests/test_tokenizer.py::test_10kbp_sequence_creates_expected_window_count` - Expected 47 windows, got 2
3. `models/llama3/tests/test_tokenizer.py::test_overlapping_windows_creates_more_samples` - Expected 47/20 windows, got 2
4. `models/llama3/tests/test_tokenizer.py::test_production_window_length_creates_expected_samples` - Expected 7 windows, got 2

## Changes
- `models/llama3/requirements.txt`: `transformers` → `transformers<5`
- `recipes/llama3_native_te/requirements.txt`: `transformers` → `transformers<5`

## Verification
- Commit signed with SSH key (verified: true, reason: valid)
- Signed-off-by trailer present
- pre-commit checks pass

## Risk
Low - stays on Transformers 4.x until tokenizer artifact/windowing behavior is validated against Transformers 5. CI will rerun the four focused tests in its normal container.