### PR TITLE
fix(ci): keep llama3 on transformers 5.x (exclude 5.16 windowing regression) and make inv_freq non-persistent

### DIFF
--- a/models/llama3/modeling_llama_te.py
+++ b/models/llama3/modeling_llama_te.py
@@ -245,9 +245,12 @@ class NVLlamaModel(NVLlamaPreTrainedModel):
         )
 
         # We use TE's RotaryPositionEmbedding, but we ensure that we use the same inv_freq as the original
-        # LlamaRotaryEmbedding.
+        # LlamaRotaryEmbedding. TE registers this buffer as persistent by default; re-register it as a
+        # non-persistent buffer so it is recomputed deterministically from config instead of being
+        # round-tripped through the checkpoint. This matches how transformers 5 (meta-device) reloads of
+        # this model treat the buffer, and keeps its persistence consistent across transformers 4 and 5.
         self.rotary_emb = RotaryPositionEmbedding(config.hidden_size // config.num_attention_heads)
-        self.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=config).inv_freq
+        self.rotary_emb.register_buffer("inv_freq", LlamaRotaryEmbedding(config=config).inv_freq, persistent=False)
         self._rotary_inv_freq_needs_init = self.rotary_emb.inv_freq.device.type == "meta"
 
         self._fp8_recipe: transformer_engine.common.recipe.Recipe | None = None

--- a/models/llama3/requirements.txt
+++ b/models/llama3/requirements.txt
@@ -2,5 +2,7 @@ lm-eval  # For testing
 torch
 torchao!=0.14.0
 transformer_engine[pytorch]
-transformers
+# Stay on transformers 5.x but exclude 5.16+: the 5.16.0/5.16.1 releases regressed
+# return_overflowing_tokens windowing (stride yielded only the final overflow window).
+transformers>=5.0.0,<5.16
 pytest

--- a/models/llama3/requirements.txt
+++ b/models/llama3/requirements.txt
@@ -4,5 +4,7 @@ torchao!=0.14.0
 transformer_engine[pytorch]
 # Stay on transformers 5.x but exclude 5.16+: the 5.16.0/5.16.1 releases regressed
 # return_overflowing_tokens windowing (stride yielded only the final overflow window).
+# Upstream report: https://github.com/huggingface/tokenizers/issues/2091
+# Proposed fix: https://github.com/huggingface/tokenizers/pull/2098
 transformers>=5.0.0,<5.16
 pytest

--- a/recipes/llama3_native_te/modeling_llama_te.py
+++ b/recipes/llama3_native_te/modeling_llama_te.py
@@ -251,9 +251,12 @@ class NVLlamaModel(NVLlamaPreTrainedModel):
         )
 
         # We use TE's RotaryPositionEmbedding, but we ensure that we use the same inv_freq as the original
-        # LlamaRotaryEmbedding.
+        # LlamaRotaryEmbedding. TE registers this buffer as persistent by default; re-register it as a
+        # non-persistent buffer so it is recomputed deterministically from config instead of being
+        # round-tripped through the checkpoint. This matches how transformers 5 (meta-device) reloads of
+        # this model treat the buffer, and keeps its persistence consistent across transformers 4 and 5.
         self.rotary_emb = RotaryPositionEmbedding(config.hidden_size // config.num_attention_heads)
-        self.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=config).inv_freq
+        self.rotary_emb.register_buffer("inv_freq", LlamaRotaryEmbedding(config=config).inv_freq, persistent=False)
         self._rotary_inv_freq_needs_init = self.rotary_emb.inv_freq.device.type == "meta"
 
         self._fp8_recipe: transformer_engine.common.recipe.Recipe | None = None

--- a/recipes/llama3_native_te/requirements.txt
+++ b/recipes/llama3_native_te/requirements.txt
@@ -7,6 +7,8 @@ torchmetrics
 tqdm
 # Stay on transformers 5.x but exclude 5.16+: the 5.16.0/5.16.1 releases regressed
 # return_overflowing_tokens windowing (stride yielded only the final overflow window).
+# Upstream report: https://github.com/huggingface/tokenizers/issues/2091
+# Proposed fix: https://github.com/huggingface/tokenizers/pull/2098
 transformers>=5.0.0,<5.16
 wandb
 zstandard

--- a/recipes/llama3_native_te/requirements.txt
+++ b/recipes/llama3_native_te/requirements.txt
@@ -5,7 +5,9 @@ torchao!=0.14.0
 torchdata
 torchmetrics
 tqdm
-transformers
+# Stay on transformers 5.x but exclude 5.16+: the 5.16.0/5.16.1 releases regressed
+# return_overflowing_tokens windowing (stride yielded only the final overflow window).
+transformers>=5.0.0,<5.16
 wandb
 zstandard
 nvdlfw_inspect @ git+https://github.com/NVIDIA/nvidia-dlfw-inspect

--- a/recipes/opengenome2_llama_native_te/modeling_llama_te.py
+++ b/recipes/opengenome2_llama_native_te/modeling_llama_te.py
@@ -251,9 +251,12 @@ class NVLlamaModel(NVLlamaPreTrainedModel):
         )
 
         # We use TE's RotaryPositionEmbedding, but we ensure that we use the same inv_freq as the original
-        # LlamaRotaryEmbedding.
+        # LlamaRotaryEmbedding. TE registers this buffer as persistent by default; re-register it as a
+        # non-persistent buffer so it is recomputed deterministically from config instead of being
+        # round-tripped through the checkpoint. This matches how transformers 5 (meta-device) reloads of
+        # this model treat the buffer, and keeps its persistence consistent across transformers 4 and 5.
         self.rotary_emb = RotaryPositionEmbedding(config.hidden_size // config.num_attention_heads)
-        self.rotary_emb.inv_freq = LlamaRotaryEmbedding(config=config).inv_freq
+        self.rotary_emb.register_buffer("inv_freq", LlamaRotaryEmbedding(config=config).inv_freq, persistent=False)
         self._rotary_inv_freq_needs_init = self.rotary_emb.inv_freq.device.type == "meta"
 
         self._fp8_recipe: transformer_engine.common.recipe.Recipe | None = None


### PR DESCRIPTION
## Summary

Keeps the llama3 environments on **transformers 5.x** (latest good 5.15.x) rather than downgrading to 4.x, and makes the llama3 model's rotary `inv_freq` buffer non-persistent so all `models/llama3` CI passes.

## Why / root cause

Two separate issues broke the llama3 nightly lanes:

1. **Tokenizer windowing regression (transformers 5.16.x only).** The unpinned `transformers` constraint resolved to 5.16.x, which regressed the fast tokenizer's `return_overflowing_tokens` windowing: with `max_length` + `stride` it returned only the final overflow window instead of all overlapping windows. Verified: transformers 5.0.0–5.15.x produce correct windows (e.g. 47 for 10kbp/1000/800); **5.16.0+ return 2**. The llama3 training dataset (`dataset.py`) relies on this for windowed training data, so it's a real production regression, not just a test artifact.
   - Fix: pin `transformers>=5.0.0,<5.16` (resolves to 5.15.1) — stay on transformers 5, avoid the one broken release line.

2. **Rotary `inv_freq` buffer persistence.** Transformer Engine registers `inv_freq` as a persistent buffer, but under transformers 5's meta-device checkpoint loading it is re-registered as non-persistent, so `test_rotary_inv_freq_after_from_pretrained` (added in #1715) asserted non-persistence. On transformers 4 it stayed persistent and the test failed.
   - Fix: re-register `inv_freq` as a **non-persistent** buffer in `NVLlamaModel` so persistence is consistent across transformers versions and the deterministic value is recomputed from config instead of round-tripped through the checkpoint.

## Changes

- `models/llama3/requirements.txt`, `recipes/llama3_native_te/requirements.txt`: `transformers>=5.0.0,<5.16`
- `models/llama3/modeling_llama_te.py` (and copied files `recipes/llama3_native_te`, `recipes/opengenome2_llama_native_te`): register `inv_freq` non-persistent, propagated via `ci/scripts/check_copied_files.py --fix`

## Validation (in CI container, pytorch26.04)

- transformers resolved to 5.15.1
- Tokenizer windowing: 10kbp→47 windows, production (8192/200)→7 windows ✅
- All assertions of `test_rotary_inv_freq_after_from_pretrained` pass (non-persistent buffer, correct device/dtype/value, `tie_weights` preserves customization) ✅
- `check_copied_files.py` and pre-commit pass ✅

Supersedes/closes #1721 (which pinned `transformers<5`).

## Upstream tracking

- [tokenizers#2091](https://github.com/huggingface/tokenizers/issues/2091): open report for the `Encoding.overflowing` regression introduced in tokenizers 0.23.1
- [tokenizers#2098](https://github.com/huggingface/tokenizers/pull/2098): proposed upstream fix with truncation and stride regression tests
- [transformers#46381](https://github.com/huggingface/transformers/pull/46381): adoption of tokenizers 0.23.1, including the changed overflow expectation
