### PR TITLE
fix(ci): repair nightly recipes failure (run 34209092165)

### DIFF
--- a/recipes/evo2_megatron/examples/lora-fine-tuning-tutorial.ipynb
+++ b/recipes/evo2_megatron/examples/lora-fine-tuning-tutorial.ipynb
@@ -273,40 +273,40 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "cell-008",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  wrote splice_train.jsonl: 27000 examples\n",
-      "  wrote splice_val.jsonl: 3000 examples\n",
-      "  wrote splice_test.jsonl: 3000 examples\n"
+     "cell_type": "code",
+     "execution_count": 3,
+     "id": "cell-008",
+     "metadata": {},
+     "outputs": [
+      {
+       "name": "stdout",
+       "output_type": "stream",
+       "text": [
+        "  wrote splice_train.jsonl: 27000 examples\n",
+        "  wrote splice_val.jsonl: 3000 examples\n",
+        "  wrote splice_test.jsonl: 3000 examples\n"
+       ]
+      }
+     ],
+     "source": [
+      "import json\n",
+      "\n",
+      "\n",
+      "def to_jsonl(df: pd.DataFrame, path: str) -> None:\n",
+      "    \"\"\"Write each row of ``df`` as a JSONL record with sequence and label fields.\"\"\"\n",
+      "    with open(path, \"w\") as f:\n",
+      "        f.writelines(\n",
+      "            json.dumps({\"sequence\": str(row[\"sequence\"]).upper(), \"label\": int(row[\"label\"])}) + \"\\n\"\n",
+      "            for _, row in df.iterrows()\n",
+      "        )\n",
+      "    print(f\"  wrote {path}: {len(df)} examples\")\n",
+      "\n",
+      "\n",
+      "to_jsonl(train_df_s, \"splice_train.jsonl\")\n",
+      "to_jsonl(val_df_s, \"splice_val.jsonl\")\n",
+      "to_jsonl(test_df, \"splice_test.jsonl\")"
      ]
-    }
-   ],
-   "source": [
-    "import json\n",
-    "\n",
-    "\n",
-    "def to_jsonl(df: pd.DataFrame, path: str) -> None:\n",
-    "    \"\"\"Write each row of ``df`` as a JSONL record with sequence and label fields.\"\"\"\n",
-    "    with open(path, \"w\") as f:\n",
-    "        f.writelines(\n",
-    "            json.dumps({\"sequence\": str(row.sequence).upper(), \"label\": int(row.label)}) + \"\\n\"\n",
-    "            for row in df.itertuples(index=False)\n",
-    "        )\n",
-    "    print(f\"  wrote {path}: {len(df)} examples\")\n",
-    "\n",
-    "\n",
-    "to_jsonl(train_df_s, \"splice_train.jsonl\")\n",
-    "to_jsonl(val_df_s, \"splice_val.jsonl\")\n",
-    "to_jsonl(test_df, \"splice_test.jsonl\")"
-   ]
-  },
+    },
   {
    "cell_type": "markdown",
    "id": "cell-009",

--- a/recipes/evo2_phage_gen/tests/bionemo/evo2_phage_gen/test_nemo_rl_env.py
+++ b/recipes/evo2_phage_gen/tests/bionemo/evo2_phage_gen/test_nemo_rl_env.py
@@ -29,8 +29,8 @@ from bionemo.evo2_phage_gen.design_scope import HostDomain, HostEvidence
 from bionemo.evo2_phage_gen.nemo_rl_env import (
     TIMING_METRIC_MARKER_PREFIX,
     GDPOObjective,
-    _scored_records,
     _is_bounded_utf8,
+    _scored_records,
     extract_assistant_sequence,
     extract_scored_sequence,
     gdpo_objective_scores_from_scored,

--- a/recipes/evo2_phage_gen/tests/bionemo/evo2_phage_gen/test_nemo_rl_env.py
+++ b/recipes/evo2_phage_gen/tests/bionemo/evo2_phage_gen/test_nemo_rl_env.py
@@ -30,6 +30,7 @@ from bionemo.evo2_phage_gen.nemo_rl_env import (
     TIMING_METRIC_MARKER_PREFIX,
     GDPOObjective,
     _scored_records,
+    _is_bounded_utf8,
     extract_assistant_sequence,
     extract_scored_sequence,
     gdpo_objective_scores_from_scored,
@@ -975,7 +976,6 @@ def test_scored_records_exclude_full_sequence_from_rollout_metadata():
             "safety_nested_payload": [{"state": "PASS"}],
             "safety_list_payload": [["PASS"]],
             "safety_unbounded_payload": ["x" * 4097],
-            "safety_invalid_unicode": ["\ud800"],
             "reward_nonfinite": [float("inf")],
             "reward_nan": [float("nan")],
             "reward_complex": [1 + 2j],
@@ -1001,6 +1001,15 @@ def test_scored_records_exclude_full_sequence_from_rollout_metadata():
         }
     ]
     json.dumps(records, allow_nan=False)
+
+
+def test_is_bounded_utf8_rejects_surrogate_characters():
+    """Surrogate characters cannot be encoded to UTF-8 and should be rejected."""
+    assert _is_bounded_utf8("\ud800") is False
+    assert _is_bounded_utf8("\udfff") is False
+    # Valid unicode should pass
+    assert _is_bounded_utf8("hello") is True
+    assert _is_bounded_utf8("🧬") is True
 
 
 def test_global_post_process_metrics_leave_task_namespace_to_nemo_rl():


### PR DESCRIPTION
## Nightly CI Repair for Run 34209092165

This PR addresses failures in the scheduled nightly workflow run [34209092165](https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/34209092165).

### Failed Jobs
1. **notebook-tests (evo2_megatron)** - `AttributeError: Pandas object has no attribute label` in `examples/lora-fine-tuning-tutorial.ipynb`
2. **unit-tests (recipes/evo2_phage_gen)** - 4 test failures:
   - `test_scored_records_exclude_full_sequence_from_rollout_metadata` - UnicodeEncodeError with surrogate character
   - `test_measured_review_gets_bounded_class_credit_but_cannot_pass_the_safety_gate` - reward_safety_toxin = 0.0 vs expected 0.25
   - `test_clean_scan_emits_independent_safety_rewards` - safety_environment_healthy = 0.0 vs expected 1.0
   - `test_mixed_batch_isolates_each_required_failure_and_unscannable_record` - only first record gets safety_scan_record_id
3. **verify-recipe-tests** - Failed due to upstream dependency failures

### Root Causes & Fixes

#### 1. Notebook Test (evo2_megatron) - FIXED
**Root Cause**: pandas 3.x changed `itertuples()` behavior. The notebook used `df.itertuples(index=False)` with `row.sequence` and `row.label` attribute access, which fails after `groupby().apply()` operations.

**Fix**: Changed to `df.iterrows()` with dictionary-style access `row["sequence"]` and `row["label"]` which is more robust.

#### 2. Unicode Test (evo2_phage_gen) - FIXED
**Root Cause**: pandas 3.x with pyarrow backend cannot create DataFrames containing surrogate characters (`\ud800`). The test `test_scored_records_exclude_full_sequence_from_rollout_metadata` included `"safety_invalid_unicode": ["\ud800"]` in the test DataFrame.

**Fix**: Removed the surrogate character from the test DataFrame (the length bound is already tested with `"safety_unbounded_payload"`). Added a new unit test `test_is_bounded_utf8_rejects_surrogate_characters` that directly tests the `_is_bounded_utf8` function.

#### 3. Reward Tests (evo2_phage_gen) - BLOCKER
**Status**: Requires further investigation. The safety scan mock appears to only process the first record in the batch. The failures are:
- `test_measured_review_gets_bounded_class_credit_but_cannot_pass_the_safety_gate`: `reward_safety_toxin` = 0.0 instead of 0.25
- `test_clean_scan_emits_independent_safety_rewards`: `safety_environment_healthy` = 0.0 instead of 1.0
- `test_mixed_batch_isolates_each_required_failure_and_unscannable_record`: Only first record gets `safety_scan_record_id`

These failures suggest an issue with the safety scan mock or the reward mapping logic that needs deeper debugging.

### Testing
- The notebook fix uses standard pandas API (`iterrows()`) compatible with pandas 2.x and 3.x
- The Unicode test fix adds a focused unit test for the validation function
- Both fixes are minimal and targeted

### Verification
- Commit signed with SSH key (verified: true, reason: valid)
- Contains Signed-off-by trailer
- 2 files changed (under 10-file limit)
