### PR TITLE
Fix flaky CUDA init error in esm2_native_te DataLoader workers

### DIFF
--- a/recipes/esm2_native_te/dataset.py
+++ b/recipes/esm2_native_te/dataset.py
@@ -144,6 +144,9 @@ def create_bshd_dataloader(
     )
 
     # TODO(BIONEMO-3246) - remove the pin_memory=False once StatefulDataLoader supports pin_memory again.
+    # Worker processes are spawned rather than forked, because a forked worker inherits the parent's CUDA state
+    # without being able to use its CUDA context, and any inherited DDP/FSDP reducer then fails with
+    # "CUDA error: initialization error" when its destructor runs in the child.
     dataloader_class = StatefulDataLoader if use_stateful_dataloader else DataLoader
     train_dataloader = dataloader_class(
         tokenized_dataset,
@@ -223,6 +226,7 @@ def create_thd_dataloader(
     )
 
     # TODO(BIONEMO-3246) - remove the pin_memory=False once StatefulDataLoader supports pin_memory again.
+    # See create_bshd_dataloader for why worker processes are spawned instead of forked.
     dataloader_class = StatefulDataLoader if use_stateful_dataloader else DataLoader
     train_dataloader = dataloader_class(
         TokenPackingDataset(tokenized_dataset, max_tokens_per_batch=token_micro_batch_size),

--- a/recipes/esm2_native_te/tests/conftest.py
+++ b/recipes/esm2_native_te/tests/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import sys
 from pathlib import Path
 from unittest import mock
@@ -45,6 +46,22 @@ def pytest_collection_modifyitems(items):
     stats_tests = [item for item in items if item.name in stats_test_names]
     other_tests = [item for item in items if item.name not in stats_test_names]
     items[:] = stats_tests + other_tests
+
+
+@pytest.fixture(autouse=True)
+def release_cuda_objects():
+    """Release CUDA-backed objects left behind by each test.
+
+    The session-scope `device_mesh` fixture initializes CUDA and NCCL for the whole test session, so any DDP or FSDP
+    wrapper a test leaves alive keeps a `c10d::Reducer` around with it. When a later test starts DataLoader worker
+    processes, a worker that inherits that reducer hits "CUDA error: initialization error" as soon as the inherited
+    destructor runs, and whether that happens at all comes down to when the interpreter gets around to collecting the
+    wrapper. Collecting between tests makes that deterministic instead of leaving it to GC timing.
+    """
+    yield
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/recipes/esm2_native_te/tests/test_dataset.py
+++ b/recipes/esm2_native_te/tests/test_dataset.py
@@ -43,6 +43,12 @@ class MockDistributedConfig:
         return self.rank == 0
 
 
+def get_worker_start_method(dataloader):
+    """Return the start method the dataloader uses for its worker processes, or None if it has no workers."""
+    context = dataloader.multiprocessing_context
+    return context.get_start_method() if context is not None else None
+
+
 def test_load_dataset_state_from_latest_checkpoint(tmp_path):
     dataloader_path = tmp_path / "dl_test"
     os.makedirs(dataloader_path, exist_ok=True)
@@ -889,6 +895,48 @@ def test_token_packing_dataloader():
     batch = next(iter(dataloader))
     assert batch["input_ids"].shape[1] == 8 * 1024
     assert batch["labels"].shape[1] == 8 * 1024
+
+
+@pytest.mark.parametrize("num_workers, expected_start_method", [(0, None), (1, "spawn"), (2, "spawn")])
+@pytest.mark.parametrize("use_stateful_dataloader", [False, True])
+def test_bshd_dataloader_worker_start_method(num_workers, expected_start_method, use_stateful_dataloader):
+    """Workers must be spawned, since a forked worker inherits CUDA state it cannot use."""
+    dataloader, _ = create_bshd_dataloader(
+        distributed_config=MockDistributedConfig(rank=0, local_rank=0, world_size=1),
+        tokenizer_name="facebook/esm2_t6_8M_UR50D",
+        load_dataset_kwargs={
+            "path": "parquet",
+            "split": "train",
+            "data_files": "train.parquet",
+            "streaming": True,
+        },
+        micro_batch_size=4,
+        num_workers=num_workers,
+        use_stateful_dataloader=use_stateful_dataloader,
+    )
+
+    assert get_worker_start_method(dataloader) == expected_start_method
+
+
+@pytest.mark.parametrize("num_workers, expected_start_method", [(0, None), (1, "spawn"), (2, "spawn")])
+@pytest.mark.parametrize("use_stateful_dataloader", [False, True])
+def test_thd_dataloader_worker_start_method(num_workers, expected_start_method, use_stateful_dataloader):
+    """Workers must be spawned, since a forked worker inherits CUDA state it cannot use."""
+    dataloader, _ = create_thd_dataloader(
+        distributed_config=MockDistributedConfig(rank=0, local_rank=0, world_size=1),
+        tokenizer_name="facebook/esm2_t6_8M_UR50D",
+        load_dataset_kwargs={
+            "path": "parquet",
+            "split": "train",
+            "data_files": "train.parquet",
+            "streaming": True,
+        },
+        token_micro_batch_size=8 * 1024,
+        num_workers=num_workers,
+        use_stateful_dataloader=use_stateful_dataloader,
+    )
+
+    assert get_worker_start_method(dataloader) == expected_start_method
 
 
 @requires_multi_gpu


### PR DESCRIPTION
### Description

Fixes #1698.

Two tests in `recipes/esm2_native_te` were failing on and off in nightly CI with `CUDA error: initialization error` coming out of the DataLoader worker processes -> `test_sanity_fsdp2_fp8_stats_logging` and `test_load_dataset_state_from_latest_checkpoint`.

The `device_mesh` fixture in `tests/conftest.py` is autouse and session scoped, so CUDA and NCCL stay live for the whole run. When a test leaves a DDP or FSDP wrapper alive, the `c10d::Reducer` it holds stays alive with it. A worker process that inherits that reducer dies as soon as the inherited destructor calls `c10::cuda::ExchangeDevice`, because the child cannot use the parent's CUDA context. Whether that happened at all came down to when the interpreter got around to collecting the wrapper - which is why the same `head_sha` passed on some days and failed on others.

Two parts to this:

- `tests/conftest.py` -> a small autouse fixture that runs `gc.collect()` and `torch.cuda.empty_cache()` after every test, so a leftover wrapper is dropped at a fixed point instead of whenever GC decides to.
- `dataset.py` + `tests/test_dataset.py` -> the `multiprocessing_context="spawn"` already on both dataloader factories is what stops a worker from inheriting CUDA state in the first place, but nothing explained it and nothing checked it. Added a comment on why it is there, plus tests parametrized over `num_workers` and `use_stateful_dataloader` asserting the worker start method is `spawn` (and `None` when there are no workers), so it cannot quietly fall back to fork later.

Nothing changes for training runs - the dataloaders already spawned their workers, and the new fixture only affects the test session.

#### Usage

No user-facing API change, so there is no snippet to add here. The recipe is used exactly as before:

```python
train_dataloader, dataset_or_sampler = create_bshd_dataloader(dist_config, **args.dataset)
```

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Validation

I do not have a local GPU, so the `unit-tests (recipes/esm2_native_te)` job is the real check on this one. What I ran locally:

- `python ci/scripts/check_copied_files.py` -> passed, none of the three files are copy-mapped
- `pre-commit run --files recipes/esm2_native_te/dataset.py recipes/esm2_native_te/tests/conftest.py recipes/esm2_native_te/tests/test_dataset.py` -> all hooks passed
- `ruff check` and `ruff format --check` on the three files -> clean
- checked that `DataLoader.multiprocessing_context` hands back a context object rather than the string, which is why the new assertion goes through `get_start_method()`

Since the failure was intermittent, it would be good to get a few nightly runs on this before calling it settled.

### Pre-submit Checklist

- [ ] I have tested these changes locally (no GPU available - see Validation above)
- [x] I have updated the documentation accordingly (code comment on why workers are spawned)
- [x] I have added/updated tests as needed
- [ ] All existing tests pass successfully (needs CI, the suite is GPU-only)
